### PR TITLE
안드로이드-기기 통신 중 블루투스 이슈 수정

### DIFF
--- a/src/src.ino
+++ b/src/src.ino
@@ -93,7 +93,7 @@ void setup() {
   M0Serial.println("bluetooth Connection Wait......");  
   while(true){
     if(BTSerial.available()){
-      BTSerial.read();
+      //BTSerial.read() 이렇게 하면 맨 처음 보내는 문자가 여기서 읽히게 됨. 때문에 삭제
       break;
     }
   }
@@ -181,7 +181,7 @@ void loop() {
           M0Serial.println("input value: "+str);     
           if(str.equals("end")){
             M0Serial.println("wait to select exercise");            
-            exercise_state = 1;                                
+            exercise_state = 0; //원래 1이였는데, end후엔 값을 송출하지 않는 상태여야 하므로 0으로 바꿈.                               
           }
           str = "";                            
         }


### PR DESCRIPTION
BTSerial.available() 확인하는 부분에서 BTSerial.read()가 한번 실행되서 start를 보내면 tart만 결과에 들어오게 됨.
그래서 BTSerial.read() 한줄 삭제함.

그리고 end를 보냈을 때도 계속 값이 들어와서 확인해보니 exercise_state의 변화가 없었음. exercise_state = 1 을 0으로 바꿔서 대기상태로 바꿀 수 있게 수정함.